### PR TITLE
Plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,30 @@ module.exports = eleventyConfig => {
 
 If you want to add custom Remark plugins, use the `plugins` option.
 
+Signatures
+
+- `plugins: [<plugin-function|plugin-name>, ...<plugin-n>]`
+- `plugins: [[{ plugin: <plugin> }], ...[{ plugin: <plugin-n>, options: <plugin-options> }]]`
+
 ```js
+const emoji = require('remark-emoji');
+
 eleventyConfig.addPlugin(eleventyRemark, {
-  plugins: [require('remark-abbr')],
+  plugins: [
+    emoji,
+    require('remark-emoji'),
+    'remark-emoji',
+    {
+      plugin: emoji
+    },
+    {
+      plugin: 'remark-emoji',
+      options: {
+        padSpaceAfter: true,
+        emoticon: true
+      }
+    }
+  ],
 });
 ```
 

--- a/__tests__/src/eleventyRemark.spec.js
+++ b/__tests__/src/eleventyRemark.spec.js
@@ -30,12 +30,108 @@ describe('eleventyRemark()', () => {
 
       expect(html).toContain('*foo');
       expect(remark).toHaveBeenCalledTimes(1);
-      expect(mockUse).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
       expect(mockProcess).toHaveBeenCalledTimes(1);
     });
 
-    it('processes markdown with plugin options', async () => {
-      const plugin = eleventyRemark({ plugins: [mockRemarkPlugin] });
+    it('processes markdown with a plugin name', async () => {
+      const plugin = eleventyRemark({
+        plugins: ['../__tests__/helpers/mockRemarkPlugin'],
+      });
+      const html = await plugin.render('foo');
+
+      expect(html).toContain('foo');
+      expect(remark).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes markdown with a plugin name as object', async () => {
+      const plugin = eleventyRemark({
+        plugins: [
+          {
+            plugin: '../__tests__/helpers/mockRemarkPlugin'
+          }
+        ]
+      });
+      const html = await plugin.render('foo');
+
+      expect(html).toContain('foo');
+      expect(remark).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes markdown with a plugin name with options as object', async () => {
+      const plugin = eleventyRemark({
+        plugins: [
+          {
+            plugin: '../__tests__/helpers/mockRemarkPlugin',
+            options: {}
+          }
+        ],
+      });
+      const html = await plugin.render('foo');
+
+      expect(html).toContain('foo');
+      expect(remark).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes markdown with a plugin function', async () => {
+      const plugin = eleventyRemark({
+        plugins: [mockRemarkPlugin],
+      });
+      const html = await plugin.render('foo');
+
+      expect(html).toContain('foo');
+      expect(remark).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes markdown with a plugin function as object', async () => {
+      const plugin = eleventyRemark({
+        plugins: [
+          {
+            plugin: mockRemarkPlugin
+          }
+        ],
+      });
+      const html = await plugin.render('foo');
+
+      expect(html).toContain('foo');
+      expect(remark).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes markdown with a plugin function as object', async () => {
+      const plugin = eleventyRemark({
+        plugins: [
+          {
+            plugin: mockRemarkPlugin
+          }
+        ],
+      });
+      const html = await plugin.render('foo');
+
+      expect(html).toContain('foo');
+      expect(remark).toHaveBeenCalledTimes(1);
+      expect(mockUse).toHaveBeenCalledTimes(2);
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes markdown with a plugin function as object', async () => {
+      const plugin = eleventyRemark({
+        plugins: [
+          {
+            plugin: mockRemarkPlugin,
+            options: {}
+          }
+        ],
+      });
       const html = await plugin.render('foo');
 
       expect(html).toContain('foo');
@@ -54,6 +150,34 @@ describe('eleventyRemark()', () => {
         await plugin.render('foo');
       } catch (error) {
         expect(error).toBe('Invalid');
+      }
+    });
+
+    it('should handle errors when plugin passed to plugin option is not a function, string or object', async () => {
+      const mockProcess = jest.fn((str, cb) => cb(undefined, str));
+      const mockProcessor = { use: mockUse, process: mockProcess };
+      mockUse.mockReturnValue(mockProcessor);
+
+      try {
+        const plugin = eleventyRemark({ plugins: [null] });
+        await plugin.render('foo');
+      } catch (error) {
+        expect(error.message).toBe(
+          'plugin has to be an instance of a remark plugin or the name of one'
+        );
+      }
+    });
+
+    it('should handle errors when plugin option is not an array', async () => {
+      const mockProcess = jest.fn((str, cb) => cb(undefined, str));
+      const mockProcessor = { use: mockUse, process: mockProcess };
+      mockUse.mockReturnValue(mockProcessor);
+
+      try {
+        const plugin = eleventyRemark({ plugins: 'some-text' });
+        await plugin.render('foo');
+      } catch (error) {
+        expect(error.message).toBe('plugins option is not an array');
       }
     });
   });

--- a/__tests__/src/eleventyRemark.spec.js
+++ b/__tests__/src/eleventyRemark.spec.js
@@ -163,7 +163,7 @@ describe('eleventyRemark()', () => {
         await plugin.render('foo');
       } catch (error) {
         expect(error.message).toBe(
-          'plugin has to be an instance of a remark plugin or the name of one'
+          'plugin has to be a function or a string, object type passed'
         );
       }
     });

--- a/src/eleventyRemark.js
+++ b/src/eleventyRemark.js
@@ -14,9 +14,7 @@ function requirePlugins(plugins) {
       return require(item);
     }
 
-    throw new Error(
-      'plugin has to be an instance of a remark plugin or the name of one'
-    );
+    throw new Error(`plugin has to be a function or a string, ${typeof item} type passed`);
   };
 
   const list = plugins.map((item) => {


### PR DESCRIPTION
Added support to remark plugin options that some plugins require like `remark-emoji`.

```javascript
const remark = require("remark");
const emoji = require("remark-emoji");

const doc = "Emojis in this text will be replaced: :dog: :+1:";
const contents = remark()
  .use(emoji, {
    padSpaceAfter: true,
    emoticon: true,
  })
  .process(doc).contents;

console.log(contents);
```