### PR TITLE
Add option to enable rehype (defaults to `true`)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@ import eleventyRemark from './src/eleventyRemark';
 
 const defaultEleventyRemarkOptions = {
   plugins: [],
+  enableRehype: true,
 };
 
 export default {

--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ eleventyConfig.addPlugin(eleventyRemark, {
 });
 ```
 
+### Additional options
+
+#### `enableRehype` (defaults to `true`)
+
+If `true` the plugins `remark-rehype` and `rehype-stringify` are added to the processor. Set `enableRehype` to `false` if you want either not use `remark-rehype` and `rehype-stringify` at all or if you want to call these plugins with custom options. For example, to enable HTML inside your Markdown you need to use `rehype-raw`:
+
+```
+eleventyConfig.addPlugin(eleventyRemark, {
+  enableRehype: false,
+  plugins: [
+    {
+      plugin: remarkRehype,
+      options: { allowDangerousHtml: true }
+    },
+    rehypeRaw,
+    rehypeStringify
+  ],
+});
+```
+
 # Contributing
 
 To contribute to `eleventy-plugin-remark`, follow these steps:

--- a/__tests__/src/eleventyRemark.spec.js
+++ b/__tests__/src/eleventyRemark.spec.js
@@ -4,6 +4,11 @@ import remark from 'remark';
 
 jest.mock('remark');
 
+const defaultOptions = {
+  enableRehype: true,
+  plugins: [],
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -11,7 +16,7 @@ beforeEach(() => {
 describe('eleventyRemark()', () => {
   describe('set()', () => {
     it('should be defined', () => {
-      const plugin = eleventyRemark({ plugins: [] });
+      const plugin = eleventyRemark(defaultOptions);
 
       expect(plugin.set()).toBeUndefined();
     });
@@ -23,10 +28,10 @@ describe('eleventyRemark()', () => {
     const mockProcessor = { use: mockUse, process: mockProcess };
     mockUse.mockReturnValue(mockProcessor);
     remark.mockReturnValue(mockProcessor);
-    mockProcess.mockImplementation((str) => Promise.resolve({contents: str}));
+    mockProcess.mockImplementation((str) => Promise.resolve({ contents: str }));
 
     it('processes markdown with default options', async () => {
-      const plugin = eleventyRemark({ plugins: [] });
+      const plugin = eleventyRemark(defaultOptions);
       const html = await plugin.render('*foo*');
 
       expect(html).toContain('*foo');
@@ -35,8 +40,25 @@ describe('eleventyRemark()', () => {
       expect(mockProcess).toHaveBeenCalledTimes(1);
     });
 
+    it('enabled rehype by default', async () => {
+      const plugin = eleventyRemark(defaultOptions);
+      const html = await plugin.render('*foo*');
+
+      expect(mockUse).toHaveBeenCalledTimes(3);
+      expect(`${mockUse.mock.calls[1][0]}`).toContain('remark2rehype');
+      expect(`${mockUse.mock.calls[2][0]}`).toContain('stringify');
+    });
+
+    it('not enables rehype if enableRehype option is `false`', async () => {
+      const plugin = eleventyRemark({ ...defaultOptions, enableRehype: false });
+      const html = await plugin.render('*foo*');
+
+      expect(mockUse).toHaveBeenCalledTimes(1);
+    });
+
     it('processes markdown with a plugin name', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: ['../__tests__/helpers/mockRemarkPlugin'],
       });
       const html = await plugin.render('foo');
@@ -49,6 +71,7 @@ describe('eleventyRemark()', () => {
 
     it('processes markdown with a plugin name as object', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: [
           {
             plugin: '../__tests__/helpers/mockRemarkPlugin',
@@ -65,6 +88,7 @@ describe('eleventyRemark()', () => {
 
     it('processes markdown with a plugin name with options as object', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: [
           {
             plugin: '../__tests__/helpers/mockRemarkPlugin',
@@ -82,6 +106,7 @@ describe('eleventyRemark()', () => {
 
     it('processes markdown with a plugin function', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: [mockRemarkPlugin],
       });
       const html = await plugin.render('foo');
@@ -94,6 +119,7 @@ describe('eleventyRemark()', () => {
 
     it('processes markdown with a plugin function as object', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: [
           {
             plugin: mockRemarkPlugin,
@@ -110,6 +136,7 @@ describe('eleventyRemark()', () => {
 
     it('processes markdown with a plugin function as object', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: [
           {
             plugin: mockRemarkPlugin,
@@ -126,6 +153,7 @@ describe('eleventyRemark()', () => {
 
     it('processes markdown with a plugin function as object', async () => {
       const plugin = eleventyRemark({
+        ...defaultOptions,
         plugins: [
           {
             plugin: mockRemarkPlugin,
@@ -147,7 +175,7 @@ describe('eleventyRemark()', () => {
       mockUse.mockReturnValue(mockProcessor);
 
       try {
-        const plugin = eleventyRemark({ plugins: [] });
+        const plugin = eleventyRemark(defaultOptions);
         await plugin.render('foo');
       } catch (error) {
         expect(error).toBe('Invalid');
@@ -160,7 +188,7 @@ describe('eleventyRemark()', () => {
       mockUse.mockReturnValue(mockProcessor);
 
       try {
-        const plugin = eleventyRemark({ plugins: [null] });
+        const plugin = eleventyRemark({ ...defaultOptions, plugins: [null] });
         await plugin.render('foo');
       } catch (error) {
         expect(error.message).toBe(
@@ -175,7 +203,10 @@ describe('eleventyRemark()', () => {
       mockUse.mockReturnValue(mockProcessor);
 
       try {
-        const plugin = eleventyRemark({ plugins: 'some-text' });
+        const plugin = eleventyRemark({
+          ...defaultOptions,
+          plugins: 'some-text',
+        });
         await plugin.render('foo');
       } catch (error) {
         expect(error.message).toBe('plugins option is not an array');

--- a/src/eleventyRemark.js
+++ b/src/eleventyRemark.js
@@ -37,8 +37,12 @@ function requirePlugins(plugins) {
 
 function eleventyRemark(options) {
   const processor = remark();
-  let plugins = requirePlugins(options.plugins);
-  processor.use(plugins).use(remarkRehype).use(rehypeStringify);
+  const plugins = requirePlugins(options.plugins);
+  processor.use(plugins);
+
+  if (options.enableRehype) {
+    processor.use(remarkRehype).use(rehypeStringify);
+  }
 
   return {
     set: () => {},


### PR DESCRIPTION
This PR adds a new option `enableRehype` (defaults to `true`) that allows to disable the automatic inclusion of the `remark-rehype` and `rehype-stringify` plugins in the processor.

This fixes https://github.com/florianeckerstorfer/remark-images/issues/7