### PR TITLE
Update Rollup config: update externals, explictily set default export

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,12 +5,13 @@ export default [
       {
         file: 'dist/eleventy.cjs.js',
         format: 'cjs',
+        exports: 'default',
       },
       {
         file: 'dist/eleventy.esm.js',
         format: 'esm',
       },
     ],
-    external: ['remark', 'remark-html'],
+    external: ['remark', 'remark-rehype', 'rehype-stringify'],
   },
 ];


### PR DESCRIPTION
This fixes two issues that Rollup complained about during build:

- [Warning: "Treating [module] as external dependency"](https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency)
- Correct configuration out [output.exports](https://rollupjs.org/guide/en/#outputexports)