### PR TITLE
Create processor for each render to allow per-page data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fec/eleventy-plugin-remark",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Eleventy plugin to process Markdown files with Remark",
   "main": ".eleventy.js",
   "scripts": {

--- a/src/eleventyRemark.js
+++ b/src/eleventyRemark.js
@@ -46,10 +46,10 @@ async function createProcessor(options) {
 }
 
 function eleventyRemark(options) {
-  const processor = createProcessor(options);
   return {
     set: () => {},
     render: (str, data) => {
+      const processor = createProcessor(options);
       return processor
         .then((p) => p.data({ eleventy: data }).process(str))
         .then((result) => result.value);


### PR DESCRIPTION
This is required since setting data is not allowed after the processor has been frozen, which happens when process() is called. The previous behaviour allowed only the processing of a single file