### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "node": ">=12.17.0"
   },
   "dependencies": {
-    "rehype-stringify": "^9.0.2",
-    "remark": "^14.0.2",
-    "remark-rehype": "^10.0.1"
+    "rehype-stringify": "^10.0.0",
+    "remark": "^15.0.1",
+    "remark-rehype": "^11.0.0"
   }
 }


### PR DESCRIPTION
I'd like to get the fix added in https://github.com/micromark/micromark/pull/158.

I've tested this against my local project and it seems to work fine.

There are a few minor breaking changes, aside from all now requiring Node 16.

- [`rehype-stringify@10.0.0`](https://github.com/rehypejs/rehype/releases/tag/13.0.0): `entities` → `characterReferences`
- [`remark@15.0.0`](https://github.com/remarkjs/remark/releases/tag/15.0.0) some changes around code fences
- [`remark-rehype@11.0.0`](https://github.com/remarkjs/remark-rehype/releases/tag/11.0.0)